### PR TITLE
Add README and make file paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+*.swp
 *.gz
 
-data/trip-updates-archive-*
+/data

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# gtfsrt-exploration
+
+## Set up
+
+-	Install MongoDB, Python 2 with pip
+-	sudo pip2 install pymongo numpy pyproj protobuf gtfs-realtime-bindings matplotlib emcee shapely
+
+Data folder:
+
+-	Create a directory called `data` in the root of the repo
+-	Create a directory (or symlink) at `data/gtfs` containing the GTFS data
+	files (e.g. run `ln -s $HOME/grt-gtfs data/gtfs`).
+-	Create a directory (or symlink) at `data/gtfs-rt` containing the
+	de-duplicated GTFS-RT archive files ([download for GRT from
+	here](https://www.timmclean.net/tritag/)).

--- a/load_rt_data.py
+++ b/load_rt_data.py
@@ -23,7 +23,7 @@ collection.create_index([
 processed_times = []
 feed = gtfs_realtime_pb2.FeedMessage()
 
-for filename in glob('/Users/mboos/grt/exploration/data/vehicle-positions-*.tar.gz'):
+for filename in glob('data/gtfs-rt/vehicle-positions-deduped-archive-*.tar.bz2'):
     print filename
     last_samples = {}
     with tarfile.open(filename) as tf:

--- a/route_speed_sample.py
+++ b/route_speed_sample.py
@@ -26,7 +26,7 @@ errors_x = []
 errors_y = []
 proj = pyproj.Proj(proj='utm', zone=17, ellps='WGS84')
 
-grt_folder = '/Users/mboos/dev/grt-gtfs'
+grt_folder = 'data/gtfs'
 with open(os.path(grt_folder, 'shapes.txt')) as fp:
     shape_lines = read_csv(fp)
 shape_data = {}


### PR DESCRIPTION
Change data file paths to work on any computer.

To get things working again on your computer:

-	Create a directory called `data` in the root of the repo
-	Create a directory (or symlink) at `data/gtfs` containing the GTFS data files (e.g. run `ln -s $HOME/dev/grt-gtfs data/gtfs`).
-	Create a directory (or symlink) at `data/gtfs-rt` containing the de-duplicated GTFS-RT archive files ([download for GRT from here](https://www.timmclean.net/tritag/)).
